### PR TITLE
convert new Buffer() to Buffer.from()

### DIFF
--- a/src/internal.ts
+++ b/src/internal.ts
@@ -22,12 +22,12 @@ export async function generateDocument(zip: JSZip) {
       type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
     })
   } else {
-    return new Buffer(new Uint8Array(buffer))
+    return Buffer.from(new Uint8Array(buffer))
   }
 }
 
 function getBinaryData(str: string) {
-  return isBrowser ? new Blob([str]) : new Buffer(str, 'utf-8')
+  return isBrowser ? new Blob([str]) : Buffer.from(str, 'utf-8')
 }
 
 function renderDocumentFile(documentOptions: DocumentOptions) {


### PR DESCRIPTION
This PR changes two instances of `new Buffer()` to use `Buffer.from()` instead

Using `new Buffer()` in `src/internal.ts` causes the following deprecation warning.

> (node:5153) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

Link to information about the deprecation on Node's docs:
https://nodejs.org/api/buffer.html#buffer_new_buffer_string_encoding

